### PR TITLE
Display Cargo.lock changes in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Display diffs in PRs
+Cargo.lock linguist-generated=false


### PR DESCRIPTION
When our dependencies change, it's useful to see what is actually
changing in `Cargo.lock`. This change adds a `.gitattributes` file that
enables this.

Signed-off-by: Oliver Gould <ver@buoyant.io>