### PR TITLE
ci: Fix the lints workflow

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,17 +1,22 @@
 name: lints
+
 on:
    pull_request:
      paths:
        - rust-toolchain
-       - src
+       - '*.rs'
        - .github/workflows/lints.yml
+
 permissions:
    contents: read
+
 env:
+  CARGO_ACTION_FMT_VERSION: v0.1.3
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
+
 jobs:
   fmt:
     timeout-minutes: 5
@@ -22,12 +27,16 @@ jobs:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: rustup component add rustfmt
       - run: cargo fmt --all -- --check
+
   clippy:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     container:
       image: docker://rust:1.58.1
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: rustup component add clippy
-      - run: cargo clippy --workspace --all-targets
+      - run: |
+          curl --proto =https --tlsv1.3 -vsSfLo /usr/local/bin/cargo-action-fmt "https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F${CARGO_ACTION_FMT_VERSION}/cargo-action-fmt-x86_64-unknown-linux-gnu"
+          chmod 755 /usr/local/bin/cargo-action-fmt
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: cargo clippy --workspace --all-targets --message-format=json | cargo-action-fmt


### PR DESCRIPTION
The lints workflow currently only runs on toolchain changes due to a
missing glob. This change updates the workflow to change whenever a
`*.rs` file change.

It also configure cargo-action-fmt on clippy output.

Signed-off-by: Oliver Gould <ver@buoyant.io>