### PR TITLE
Simplify feature flagging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.69.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600ef6c2724d235b5fc725254e08d7bd1fd8de95976ca9c99d060b1cb7ce91e9"
+checksum = "71f8aa916ee8290fbd0af76b3a28093a8786fccb6286902095a5243484447971"
 dependencies = [
  "base64",
  "bytes",
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.69.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a87945c0eccb682d387c3400c50c3bd8750d80127919a0a25119d68e7bd5d0a"
+checksum = "da41f98f213796a68fcd4510c88b5fd36de131c1ea30d152474c3f2e1bef1a72"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.69.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f6527537a5a33679223b354401e328f2d665d805f7c8468b73a7cd631789e9"
+checksum = "9cd6fdc2e1615a3aecd7e90fe4bda3ba32379e38193251d4ddaccba26579fe22"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.69.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3a141c952b29f5ef3a1f0ec397dcf1a473be55f162bceac9ebec046c524330"
+checksum = "32e8bf2258850dbc0a062b561656a1d7020fa8040d552e149f0a0361f0d6794e"
 dependencies = [
  "ahash",
  "backoff",
@@ -1327,9 +1327,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
- "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,20 +5,19 @@ authors = ["Linkerd authors <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 license = "Apache-2.0"
 
-[features]
-default = ["runtime"]
-runtime = ["kube/runtime"]
-
 [dependencies]
 anyhow = "1"
 clap = { version = "3", default-features = false, features = ["derive", "env", "std"] }
 futures = "0.3"
-kube = { version = "0.69", features = ["derive"] }
+kube = { version = "0.69", features = ["derive", "runtime"] }
 k8s-openapi = { version = "0.14", default-features = false, features = ["v1_20"] }
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1.17", features = ["full"] }
 tokio-stream = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+
+[dependencies.tokio]
+version = "1"
+features = ["macros", "parking_lot", "rt", "rt-multi-thread"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,7 @@ use kube::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-use tokio::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tracing::Instrument;
 use tracing_subscriber::{prelude::*, EnvFilter};
 


### PR DESCRIPTION
Currently the `linkerd-failover` crate supports an optional `runtime`
feature that enables `kube/runtime`; but this feature isn't actually
optional and compilation fails when `--no-default-features` is used.
This feature is now always enabled and `linkerd-failover` now has no
optional features.

This change also simplifies `tokio`'s feature flags to avoid building
unnecessary functionality.

Finally, this change bumps `kube` versions to 0.69.1 to avoid a
deadlocking bug in 0.69.0.