### PR TITLE
Rename docker image to `failover`

### DIFF
--- a/bin/docker-build
+++ b/bin/docker-build
@@ -57,6 +57,6 @@ arch=$(architecture)
 # shellcheck disable=SC2086
 docker buildx build "$rootdir" $cache_params \
     $output_params \
-    -t "$DOCKER_REGISTRY/linkerd-failover:$(head_root_tag)" \
+    -t "$DOCKER_REGISTRY/failover:$(head_root_tag)" \
     -f "$rootdir/$arch.dockerfile" \
     "$@"

--- a/charts/linkerd-failover/README.md
+++ b/charts/linkerd-failover/README.md
@@ -52,7 +52,7 @@ Kubernetes: `>=1.20.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.name | string | `"linkerd-failover"` |  |
+| image.name | string | `"failover"` |  |
 | image.registry | string | `"cr.l5d.io/linkerd"` |  |
 | image.tag | string | `"latest"` |  |
 | labelSelector | string | `"app.kubernetes.io/managed-by=linkerd-failover"` | Determines which `TrafficSplit` instances to consider for failover |

--- a/charts/linkerd-failover/values.yaml
+++ b/charts/linkerd-failover/values.yaml
@@ -1,7 +1,7 @@
 # Docker image for the operator
 image:
   registry: cr.l5d.io/linkerd
-  name: linkerd-failover
+  name: failover
   tag: latest
 
 # -- Determines which `TrafficSplit` instances to consider for failover


### PR DESCRIPTION
Our other image names do not include the `linkerd-` prefix.

Signed-off-by: Oliver Gould <ver@buoyant.io>