### PR TITLE
use linkerd/dev:v9 image for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linkerd-failover.dev",
-    "dockerFile": "Dockerfile",
+    "image": "ghcr.io/linkerd/dev:v9",
     "extensions": [
         "DavidAnson.vscode-markdownlint",
         "matklad.rust-analyzer",


### PR DESCRIPTION
Using a devcontainer does not work because `Dockerfile` does not exist. This uses the `ghcr.io/linkerd/dev:v9` image similar to linkerd2.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>