### PR TITLE
Add status command 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kubert",
+ "linkerd-failover-controller",
  "serde",
  "serde_json",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ The following `TrafficSplit` serves as the initial state for a failover setup.
 
 Clients should send requests to the apex service `sample-svc`. The primary
 service that will serve these requests is declared through the
-`failover.linkerd.io/primary-service` annotation, `sample-svc` in this case. If
-the `TrafficSplit` does not include this annotaiton, it will treat the first
-backend as the primary service.
+`failover.linkerd.io/primary-service` annotation, `sample-svc` in this case.
 
 When `sample-svc` starts failing, the weights will be switched over the other
 backends.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ The following `TrafficSplit` serves as the initial state for a failover setup.
 
 Clients should send requests to the apex service `sample-svc`. The primary
 service that will serve these requests is declared through the
-`failover.linkerd.io/primary-service` annotation, `sample-svc` in this case.
+`failover.linkerd.io/primary-service` annotation, `sample-svc` in this case. If
+the `TrafficSplit` does not include this annotaiton, it will treat the first
+backend as the primary service.
 
 When `sample-svc` starts failing, the weights will be switched over the other
 backends.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 anyhow = "1"
 clap = { version = "3", default-features = false, features = ["derive", "env", "std"] }
 k8s-openapi = { version = "0.14", default-features = false, features = ["v1_20"] }
+linkerd-failover-controller = { path = "../controller" }
 serde = "1"
 serde_json = "1"
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod check;
+pub mod status;
+mod table;

--- a/cli/src/status.rs
+++ b/cli/src/status.rs
@@ -1,0 +1,96 @@
+use crate::table::{Column, Table};
+use anyhow::Result;
+use kube::{api::ListParams, Api, Client, ResourceExt};
+use linkerd_failover_controller::TrafficSplit;
+use serde::Serialize;
+use std::fmt::Display;
+
+#[derive(Serialize)]
+pub struct TrafficSplitStatus {
+    namespace: String,
+    name: String,
+    status: FailoverStatus,
+    services: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+enum FailoverStatus {
+    Primary,
+    Fallback,
+}
+
+impl Display for FailoverStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::Primary => std::fmt::Display::fmt("Primary", f)?,
+            Self::Fallback => std::fmt::Display::fmt("Fallback", f)?,
+        };
+        Ok(())
+    }
+}
+
+pub async fn status(client: Client, label_selector: &str) -> Result<Vec<TrafficSplitStatus>> {
+    let api = Api::<TrafficSplit>::all(client);
+    let list_params = ListParams::default().labels(label_selector);
+    let traffic_splits = api.list(&list_params).await?;
+    let statuses = traffic_splits
+        .items
+        .into_iter()
+        .flat_map(|ts| {
+            let primary = ts
+                .metadata
+                .annotations
+                .as_ref()
+                .and_then(|annotations| annotations.get("failover.linkerd.io/primary-service"));
+            primary.map(|primary| {
+                let active_backends = active_backends(&ts);
+                let status = if active_backends.contains(primary) {
+                    FailoverStatus::Primary
+                } else {
+                    FailoverStatus::Fallback
+                };
+                TrafficSplitStatus {
+                    namespace: ts.namespace().expect("TrafficSplits must be namespaced"),
+                    name: ts.name(),
+                    status,
+                    services: active_backends,
+                }
+            })
+        })
+        .collect();
+    Ok(statuses)
+}
+
+pub fn print_status(results: &[TrafficSplitStatus]) {
+    let columns: Vec<Column<TrafficSplitStatus>> = vec![
+        Column::new("NAMESPACE", Box::new(|r| r.namespace.clone())),
+        Column::new("TRAFFIC_SPLIT", Box::new(|r| r.name.clone())),
+        Column::new("STATUS", Box::new(|r| r.status.to_string())),
+        Column::new("ACTIVE_BACKENDS", Box::new(|r| r.services.join(", "))),
+    ];
+    let table = Table {
+        cols: columns,
+        data: results,
+    };
+    print!("{table}");
+}
+
+pub fn json_print_status(results: &[TrafficSplitStatus]) {
+    serde_json::to_writer_pretty(std::io::stdout(), &results).expect("serialization failed");
+    println!();
+}
+
+fn active_backends(ts: &TrafficSplit) -> Vec<String> {
+    ts.spec
+        .backends
+        .iter()
+        .filter_map(|backend| {
+            if backend.weight > 0 {
+                Some(backend.service.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}

--- a/cli/src/table.rs
+++ b/cli/src/table.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::{Display, Write};
 
 const PADDING: usize = 3;
 pub struct Column<T> {
@@ -17,10 +17,12 @@ impl<T> Column<T> {
     }
 
     fn width(&self, rows: &[T]) -> usize {
-        match rows.iter().map(|t| (self.value)(t).len()).max() {
-            Some(width) => self.header.len().max(width) + PADDING,
-            None => self.header.len() + PADDING,
-        }
+        let width = rows
+            .iter()
+            .map(|t| (self.value)(t).len())
+            .max()
+            .unwrap_or(0);
+        self.header.len().max(width) + PADDING
     }
 }
 
@@ -35,14 +37,14 @@ impl<'a, T> Display for Table<'a, T> {
         for (col, width) in self.cols.iter().zip(&column_widths) {
             write!(f, "{:width$}", col.header, width = width)?;
         }
-        writeln!(f)?;
+        f.write_char('\n')?;
         // Print data
         for t in self.data {
             for (col, width) in self.cols.iter().zip(&column_widths) {
                 let value = (col.value)(t);
                 write!(f, "{:width$}", value, width = width)?;
             }
-            writeln!(f)?;
+            f.write_char('\n')?;
         }
         Ok(())
     }

--- a/cli/src/table.rs
+++ b/cli/src/table.rs
@@ -1,0 +1,49 @@
+use std::fmt::Display;
+
+const PADDING: usize = 3;
+pub struct Column<T> {
+    header: &'static str,
+    value: Box<dyn Fn(&T) -> String>,
+}
+
+pub struct Table<'a, T> {
+    pub cols: Vec<Column<T>>,
+    pub data: &'a [T],
+}
+
+impl<T> Column<T> {
+    pub fn new(header: &'static str, value: Box<dyn Fn(&T) -> String>) -> Column<T> {
+        Column { header, value }
+    }
+
+    fn width(&self, rows: &[T]) -> usize {
+        match rows.iter().map(|t| (self.value)(t).len()).max() {
+            Some(width) => self.header.len().max(width) + PADDING,
+            None => self.header.len() + PADDING,
+        }
+    }
+}
+
+impl<'a, T> Display for Table<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let column_widths = self
+            .cols
+            .iter()
+            .map(|col| col.width(self.data))
+            .collect::<Vec<usize>>();
+        // Print headers
+        for (col, width) in self.cols.iter().zip(&column_widths) {
+            write!(f, "{:width$}", col.header, width = width)?;
+        }
+        writeln!(f)?;
+        // Print data
+        for t in self.data {
+            for (col, width) in self.cols.iter().zip(&column_widths) {
+                let value = (col.value)(t);
+                write!(f, "{:width$}", value, width = width)?;
+            }
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -29,7 +29,8 @@ exceptions = []
 
 [bans]
 multiple-versions = "deny"
-wildcards = "deny"
+# Wildcard dependencies are used for all workspace-local crates.
+wildcards = "allow"
 highlight = "all"
 deny = []
 skip-tree = []


### PR DESCRIPTION
Fixes #70

Adds a status command which lists all failover traffic splits and their current status.

```console
> linkerd failover status  
NAMESPACE       TRAFFIC_SPLIT   STATUS          ACTIVE BACKENDS
default         sample-svc      Fallback        sample-svc-central1, sample-svc-east1, sample-svc-east2
> linkerd failover status -o json
[
  {
    "namespace": "default",
    "name": "sample-svc",
    "status": "fallback",
    "services": [
      "sample-svc-central1",
      "sample-svc-east1",
      "sample-svc-east2"
    ]
  }
]
```