### PR TITLE
Treat first backend as primary by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ The following `TrafficSplit` serves as the initial state for a failover setup.
 
 Clients should send requests to the apex service `sample-svc`. The primary
 service that will serve these requests is declared through the
-`failover.linkerd.io/primary-service` annotation, `sample-svc` in this case.
+`failover.linkerd.io/primary-service` annotation, `sample-svc` in this case. If
+the `TrafficSplit` does not include this annotaiton, it will treat the first
+backend as the primary service.
 
 When `sample-svc` starts failing, the weights will be switched over the other
 backends.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The following `TrafficSplit` serves as the initial state for a failover setup.
 Clients should send requests to the apex service `sample-svc`. The primary
 service that will serve these requests is declared through the
 `failover.linkerd.io/primary-service` annotation, `sample-svc` in this case. If
-the `TrafficSplit` does not include this annotaiton, it will treat the first
+the `TrafficSplit` does not include this annotation, it will treat the first
 backend as the primary service.
 
 When `sample-svc` starts failing, the weights will be switched over the other

--- a/controller/src/traffic_split.rs
+++ b/controller/src/traffic_split.rs
@@ -104,10 +104,11 @@ pub(super) async fn update(target: ObjectRef<TrafficSplit>, ctx: &Ctx) {
     let primary_service = match split
         .annotations()
         .get("failover.linkerd.io/primary-service")
+        .or_else(|| split.spec.backends.first().map(|backend| &backend.service))
     {
         Some(name) => name,
         None => {
-            tracing::info!("trafficsplit is missing the `failover.linkerd.io/primary-service` annotation; skipping");
+            tracing::info!("trafficsplit has no backends; skipping");
             return;
         }
     };


### PR DESCRIPTION
Fixes #96 

If the `failover.linkerd.io/primary-service` annotation isn't present on a trafficsplit, we treat the first backend as the primary.

Signed-off-by: Alex Leong <alex@buoyant.io>