### PR TITLE
Record events when failing over

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -174,6 +174,7 @@ mod tests {
         assert_ready_eq!(
             patches.poll_next(),
             Some(traffic_split::FailoverUpdate {
+                primary_active: true,
                 target: ObjectRef::new("ts0").within("default"),
                 backends: vec![
                     backend("primary", 1),
@@ -215,6 +216,7 @@ mod tests {
         assert_ready_eq!(
             patches.poll_next(),
             Some(traffic_split::FailoverUpdate {
+                primary_active: false,
                 target: ObjectRef::new("ts0").within("default"),
                 backends: vec![
                     backend("primary", 0),

--- a/controller/src/traffic_split.rs
+++ b/controller/src/traffic_split.rs
@@ -7,6 +7,8 @@ use kube::{
 };
 use tokio::{sync::mpsc, time};
 
+const FAILOVER: &str = "Failover";
+
 /// The `split.smi-spec.io/TrafficSplit` custom resource
 #[derive(
     Clone,
@@ -187,7 +189,7 @@ async fn patch(
         instance: None,
     };
     let event_recorder = events::Recorder::new(client, event_reporter, target.clone().into());
-    let reason = if primary_active {
+    let description = if primary_active {
         format!("trafficsplit/{} switching traffic to primary", name)
     } else {
         format!("trafficsplit/{} failing over to fallbacks", name)
@@ -195,9 +197,9 @@ async fn patch(
     if let Err(error) = event_recorder
         .publish(events::Event {
             type_: events::EventType::Normal,
-            reason,
-            note: None,
-            action: String::new(),
+            reason: FAILOVER.to_string(),
+            note: Some(description),
+            action: FAILOVER.to_string(),
             secondary: None,
         })
         .await

--- a/controller/src/traffic_split.rs
+++ b/controller/src/traffic_split.rs
@@ -8,6 +8,7 @@ use kube::{
 use tokio::{sync::mpsc, time};
 
 const FAILOVER: &str = "Failover";
+const CONTROLLER_NAME: &str = "linkerd-failover";
 
 /// The `split.smi-spec.io/TrafficSplit` custom resource
 #[derive(
@@ -212,7 +213,7 @@ fn mk_patch(name: &str, backends: &[Backend]) -> serde_json::Value {
 
 async fn record_event(client: kube::Client, target: ObjectRef<TrafficSplit>, primary_active: bool) {
     let event_reporter = events::Reporter {
-        controller: "linkerd-failover".to_string(),
+        controller: CONTROLLER_NAME.to_string(),
         instance: None,
     };
     let description = if primary_active {


### PR DESCRIPTION
Fixes #73 

We emit a kubernetes event whenever a failover is triggered and we watch the TrafficSplit. 

Examples:

```
5m16s       Normal   Failover            trafficsplit/split          trafficsplit/split switching traffic to primary
10m         Normal   Failover            trafficsplit/split          trafficsplit/split failing over to fallbacks
```