### PR TITLE
ci: Use the cargo-action-fmt setup action

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -11,7 +11,6 @@ permissions:
    contents: read
 
 env:
-  CARGO_ACTION_FMT_VERSION: v0.1.3
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
@@ -34,9 +33,7 @@ jobs:
     container:
       image: docker://rust:1.59.0
     steps:
+      - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
       - run: rustup component add clippy
-      - run: |
-          curl --proto =https --tlsv1.3 -vsSfLo /usr/local/bin/cargo-action-fmt "https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F${CARGO_ACTION_FMT_VERSION}/cargo-action-fmt-x86_64-unknown-linux-gnu"
-          chmod 755 /usr/local/bin/cargo-action-fmt
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: cargo clippy --workspace --all-targets --message-format=json | cargo-action-fmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ permissions:
    contents: read
 
 env:
-  CARGO_ACTION_FMT_VERSION: v0.1.3
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
@@ -25,9 +24,7 @@ jobs:
     container:
       image: docker://rust:1.59.0
     steps:
-      - run: |
-          curl --proto =https --tlsv1.3 -vsSfLo /usr/local/bin/cargo-action-fmt "https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F${CARGO_ACTION_FMT_VERSION}/cargo-action-fmt-x86_64-unknown-linux-gnu"
-          chmod 755 /usr/local/bin/cargo-action-fmt
+      - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: cargo fetch
       - run: cargo test --frozen --workspace --no-run --message-format=json | cargo-action-fmt


### PR DESCRIPTION
The `cargo-action-fmt` setup action reduces boilerplate and can be
automatically updated by dependabot.