### PR TITLE
Revert "Bump socket2 from 0.4.4 to 0.4.5 (#201)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,12 +1214,12 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca642ba17f8b2995138b1d7711829c92e98c0a25ea019de790f4f09279c4e296"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
- "windows-sys",
+ "winapi",
 ]
 
 [[package]]


### PR DESCRIPTION
Socket2 v0.4.5 was yanked from crates.io

This reverts commit 48a87608de599f9719e1b68d1a0ecfe753b9374a.