### PR TITLE
Change notes for 1.0.0 and other fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
       run: |
         curl -sL https://run.linkerd.io/install-edge | sh
         export PATH=$PATH:~/.linkerd2/bin
+        linkerd install --crds | kubectl apply -f -
         linkerd install | kubectl apply -f -
         linkerd check
     - name: Install linkerd-smi
@@ -135,7 +136,8 @@ jobs:
         credentials_json: ${{ secrets.LINKERD_SITE_TOKEN }}
     - name: Set up Cloud SDK
       uses: 'google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb'
-    - name: Helm chart creation and upload
+    - name: Edge Helm chart creation and upload
+      if: contains(github.ref, '-edge')
       run: |
         mkdir -p target/helm
         helm --app-version "${{ github.ref_name }}" -d target/helm package charts/linkerd-failover
@@ -143,3 +145,12 @@ jobs:
         gsutil cp gs://helm.linkerd.io/edge/index.yaml "target/helm/index-pre-failover-${{ github.ref_name }}".yaml
         helm repo index --url https://helm.linkerd.io/edge/ --merge "target/helm/index-pre-failover-${{ github.ref_name }}".yaml target/helm
         gsutil rsync target/helm gs://helm.linkerd.io/edge
+    - name: Stable Helm chart creation and upload
+      if: !contains(github.ref, '-edge')
+      run: |
+        mkdir -p target/helm
+        helm --app-version "${{ github.ref_name }}" -d target/helm package charts/linkerd-failover
+        # backup index file before changing it
+        gsutil cp gs://helm.linkerd.io/stable/index.yaml "target/helm/index-pre-failover-${{ github.ref_name }}".yaml
+        helm repo index --url https://helm.linkerd.io/stable/ --merge "target/helm/index-pre-failover-${{ github.ref_name }}".yaml target/helm
+        gsutil rsync target/helm gs://helm.linkerd.io/stable

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## 1.0.0
+
+Even though 0.0.1-edge was stable enough, this is officially the first stable
+release!
+
+- Added the linkerd failover CLI
+- Started recording events when failing over
+- Started treating first backend as primary by default
+
 ## 0.0.1-edge
 
 First release!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,7 +43,7 @@ with your username and the actual release number).
 ### 2. Update the Helm charts versions
 
 - Update the `appVersion` in the `Chart.yaml` files for the `linkerd-failover`
-  and `linkerd-failover` charts. `appVersion` should match the actual
+  and `linkerd-failover-tests` charts. `appVersion` should match the actual
   version/tag.
 - Also update their `version` entry. During the first few releases this will
   match `appVersion`, but may drift apart in the future when there are changes

--- a/charts/linkerd-failover-tests/Chart.yaml
+++ b/charts/linkerd-failover-tests/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
 kubeVersion: ">=1.20.0-0"
 sources:
 - https://github.com/linkerd/linkerd-failover/
-appVersion: 0.0.1-edge
-version: 0.0.1-edge
+appVersion: 1.0.0
+version: 1.0.0
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-failover-tests/README.md
+++ b/charts/linkerd-failover-tests/README.md
@@ -1,9 +1,9 @@
 <!-- markdownlint-disable -->
 # linkerd-failover-tests
 
-![Version: 0.0.1-edge](https://img.shields.io/badge/Version-0.0.1--edge-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 0.0.1-edge](https://img.shields.io/badge/AppVersion-0.0.1--edge-informational?style=flat-square)
+![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>
 

--- a/charts/linkerd-failover/Chart.yaml
+++ b/charts/linkerd-failover/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
 kubeVersion: ">=1.20.0-0"
 sources:
 - https://github.com/linkerd/linkerd-failover/
-appVersion: 0.0.1-edge
-version: 0.0.1-edge
+appVersion: 1.0.0
+version: 1.0.0
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-failover/README.md
+++ b/charts/linkerd-failover/README.md
@@ -1,9 +1,9 @@
 <!-- markdownlint-disable -->
 # linkerd-failover
 
-![Version: 0.0.1-edge](https://img.shields.io/badge/Version-0.0.1--edge-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 0.0.1-edge](https://img.shields.io/badge/AppVersion-0.0.1--edge-informational?style=flat-square)
+![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>
 
@@ -108,7 +108,7 @@ Kubernetes: `>=1.20.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image | object | `{"name":"failover","registry":"cr.l5d.io/linkerd","tag":"0.0.1-edge"}` | Docker image |
+| image | object | `{"name":"failover","registry":"cr.l5d.io/linkerd","tag":"1.0.0"}` | Docker image |
 | logFormat | string | `"plain"` | Log format (`plain` or `json`) |
 | logLevel | string | `"linkerd=info,warn"` | Log level |
 | selector | string | `nil` | Determines which `TrafficSplit` instances to consider for failover. If empty, defaults to failover.linkerd.io/controlled-by={{ .Release.Name }} |

--- a/charts/linkerd-failover/values.yaml
+++ b/charts/linkerd-failover/values.yaml
@@ -8,7 +8,7 @@ logFormat: plain
 image:
   registry: cr.l5d.io/linkerd
   name: failover
-  tag: 0.0.1-edge
+  tag: 1.0.0
 
 # -- Determines which `TrafficSplit` instances to consider for failover. If
 # empty, defaults to failover.linkerd.io/controlled-by={{ .Release.Name }}


### PR DESCRIPTION
Note this is blocked by linkerd/linkerd2#8740

- Adds `linkerd install --crds` command to the "Install linkerd" job in `release.yml`
- Splits the "chart-deploy" job into two parts, one for edges and another for stable releases.