### PR TITLE
Docs, YAML fixes - prepare 0.0.9-edge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
         helm repo index --url https://helm.linkerd.io/edge/ --merge "target/helm/index-pre-failover-${{ github.ref_name }}".yaml target/helm
         gsutil rsync target/helm gs://helm.linkerd.io/edge
     - name: Stable Helm chart creation and upload
-      if: !contains(github.ref, '-edge')
+      if: ${{ !contains(github.ref, '-edge') }}
       run: |
         mkdir -p target/helm
         helm --app-version "${{ github.ref_name }}" -d target/helm package charts/linkerd-failover

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,12 @@ release!
 - Started recording events when failing over
 - Started treating first backend as primary by default
 
+## 0.0.9-edge
+
+- Added the linkerd failover CLI
+- Started recording events when failing over
+- Started treating first backend as primary by default
+
 ## 0.0.1-edge
 
 First release!

--- a/README.md
+++ b/README.md
@@ -54,11 +54,15 @@ helm install linkerd-smi -n linkerd-smi --create-namespace linkerd-smi/linkerd-s
 Linkerd-failover installation:
 
 ```console
-# In case you haven't added the linkerd-edge repo already
+# For edge releases
 helm repo add linkerd-edge https://helm.linkerd.io/edge
 helm repo up
-
 helm install linkerd-failover -n linkerd-failover --create-namespace --devel linkerd-edge/linkerd-failover
+
+# For stable releases
+helm repo add linkerd https://helm.linkerd.io/stable
+helm repo up
+helm install linkerd-failover -n linkerd-failover --create-namespace linkerd/linkerd-failover
 ```
 
 ## Example


### PR DESCRIPTION
- Fix `release.yml` syntax
- Include instructions for edge vs stable in `README.md`
- Prepare for a `0.0.9-edge` release before trigerring the `0.1.0`
  stable release, as per the instructions in `RELEASE.md`