### PR TITLE
chore: update `kubert` to 0.9 and `kube` to 0.74

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68b954ea9ad888de953fb1488bd8f377c4c78d82d4642efa5925189210b50b7"
+checksum = "a527a8001a61d8d470dab27ac650889938760c243903e7cd90faaf7c60a34bdd"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150dc7107d9acf4986088f284a0a6dddc5ae37ef1ffdf142f6811dc5998dd58"
+checksum = "c0d48f42df4e8342e9f488c4b97e3759d0042c4e7ab1a853cc285adb44409480"
 dependencies = [
  "base64",
  "bytes",
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8c429676abe6a73b374438d5ca02caaf9ae7a635441253c589b779fa5d0622"
+checksum = "91f56027f862fdcad265d2e9616af416a355e28a1c620bb709083494753e070d"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb405f0d39181acbfdc7c79e3fc095330c9b6465ab50aeb662d762e53b662f1"
+checksum = "66d74121eb41af4480052901f31142d8d9bbdf1b7c6b856da43bcb02f5b1b177"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e9e9da456f0101b77f864a9da44866b9891ad4740db508b4b269343ebeb01d"
+checksum = "8fdcf5a20f968768e342ef1a457491bb5661fccd81119666d626c57500b16d99"
 dependencies = [
  "ahash",
  "backoff",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "kubert"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3583ea5ed19b357df067fa668fc00ddac5d6945a5803e2114c3ed000af1f3cf"
+checksum = "6b8b65e116e2617ea081f5fcbd31d508243ab0c1c6da3fa2a7177680a61af855"
 dependencies = [
  "clap",
  "drain",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1"
 serde_json = "1"
 
 [dependencies.kube]
-version = "0.73"
+version = "0.74"
 default-features = false
 features = [
     "client",
@@ -24,7 +24,7 @@ features = [
 ]
 
 [dependencies.kubert]
-version = "0.8"
+version = "0.9"
 default-features = false
 features = [
     "clap",

--- a/cli/src/check.rs
+++ b/cli/src/check.rs
@@ -87,7 +87,7 @@ pub async fn namespace_check(client: Client) -> (CheckResult, Option<String>) {
                     result: CheckStatus::Success,
                     ..Default::default()
                 },
-                Some(ns.name()),
+                Some(ns.name_any()),
             )
         }
         Ok(ref objs) if objs.items.is_empty() => (

--- a/cli/src/status.rs
+++ b/cli/src/status.rs
@@ -52,7 +52,7 @@ pub async fn status(client: Client, label_selector: &str) -> Result<Vec<TrafficS
                 };
                 TrafficSplitStatus {
                     namespace: ts.namespace().expect("TrafficSplits must be namespaced"),
-                    name: ts.name(),
+                    name: ts.name_any(),
                     status,
                     services: active_backends,
                 }

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -17,7 +17,7 @@ tokio-stream = "0.1"
 tracing = "0.1"
 
 [dependencies.kube]
-version = "0.73"
+version = "0.74"
 default-features = false
 features = [
     "client",
@@ -27,7 +27,7 @@ features = [
 ]
 
 [dependencies.kubert]
-version = "0.8"
+version = "0.9"
 default-features = false
 features = [
     "clap",

--- a/controller/src/endpoints.rs
+++ b/controller/src/endpoints.rs
@@ -21,12 +21,13 @@ pub(super) async fn handle(ev: Event<Endpoints>, ctx: &Ctx) {
     match ev {
         Event::Applied(ep) | Event::Deleted(ep) => {
             let mut updated = 0;
+            let ep_name = ep.name_any();
             for ts in ctx.traffic_splits.state() {
                 if ts.namespace() == ep.namespace()
-                    && ts.spec.backends.iter().any(|b| b.service == ep.name())
+                    && ts.spec.backends.iter().any(|b| b.service == ep_name)
                 {
                     tracing::debug!(
-                        service = %ep.name(),
+                        service = %ep_name,
                         "updating traffic split for endpoints",
                     );
                     traffic_split::update(ObjectRef::from_obj(&*ts), ctx).await;
@@ -35,7 +36,7 @@ pub(super) async fn handle(ev: Event<Endpoints>, ctx: &Ctx) {
             }
             tracing::debug!(
                 namespace = %ep.namespace().unwrap(),
-                service = %ep.name(),
+                service = %ep_name,
                 %updated,
                 "updated endpoints"
             );


### PR DESCRIPTION
This branch updates `kubert` to v0.9 and `kube` to v0.74. This has to be
done manually as these dependencies must be updated in sync, so they
cannot be updated by Dependabot.

In addition, `kube` deprecated the `ResourceExt::name` method in 0.74,
so I've replaced uses of that method with `ResourceExt::name_any`.

Closes #295
Closes #359