### PR TITLE
Add event create rule to failover ClusterRole.

### DIFF
--- a/charts/linkerd-failover/templates/linkerd-failover-rbac.yaml
+++ b/charts/linkerd-failover/templates/linkerd-failover-rbac.yaml
@@ -12,6 +12,9 @@ rules:
 - apiGroups: [""]
   resources: ["endpoints"]
   verbs: ["list", "get", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Works on my end, fixes [#9035](https://github.com/linkerd/linkerd2/issues/9035), but only merge if the other assignee is absent. :smile: 

Signed-off-by: Dominik Táskai <dominik.taskai@leannet.eu>