### PR TITLE
Update clap and kube

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "extensions": [
         "DavidAnson.vscode-markdownlint",
         "NathanRidley.autotrim",
-        "rust-analyzer.rust-analyzer",
+        "rust-lang.rust-analyzer",
         "samverschueren.final-newline",
         "tamasfe.even-better-toml",
     ],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,10 +4,11 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
 dependencies = [
+ "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
@@ -20,15 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -56,6 +48,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -126,23 +129,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "06badb543e734a2d6568e19a40af66ed5364360b9226184926f89d229b4b4267"
 dependencies = [
+ "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
- "textwrap",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -153,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -640,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ae2c04fcee6b01b04e3aadd56bb418932c8e0a9d8a93f48bc68c6bdcdb559d"
+checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
 dependencies = [
  "base64",
  "bytes",
@@ -654,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a527a8001a61d8d470dab27ac650889938760c243903e7cd90faaf7c60a34bdd"
+checksum = "9bb19108692aeafebb108fd0a1c381c06ac4c03859652599420975165e939b8a"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -667,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d48f42df4e8342e9f488c4b97e3759d0042c4e7ab1a853cc285adb44409480"
+checksum = "97e1a80ecd1b1438a2fc004549e155d47250b9e01fbfcf4cfbe9c8b56a085593"
 dependencies = [
  "base64",
  "bytes",
@@ -702,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f56027f862fdcad265d2e9616af416a355e28a1c620bb709083494753e070d"
+checksum = "f4d780f2bb048eeef64a4c6b2582d26a0fe19e30b4d3cc9e081616e1779c5d47"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -720,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d74121eb41af4480052901f31142d8d9bbdf1b7c6b856da43bcb02f5b1b177"
+checksum = "98459d53b2841237392cd6959956185b2df15c19d32c3b275ed6ca7b7ee1adae"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -733,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fdcf5a20f968768e342ef1a457491bb5661fccd81119666d626c57500b16d99"
+checksum = "7769af142ee2e46bfa44bd393cf7f40b9d8b80d2e11f6317399551ed17760beb"
 dependencies = [
  "ahash",
  "backoff",
@@ -757,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "kubert"
-version = "0.9.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8b65e116e2617ea081f5fcbd31d508243ab0c1c6da3fa2a7177680a61af855"
+checksum = "cde503669a3277ab3c576ab3349fb21a7e82288210369b37ed65d88a14cf3e51"
 dependencies = [
  "clap",
  "drain",
@@ -1368,12 +1372,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
-
-[[package]]
 name = "thiserror"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,7 +1601,6 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
- "ansi_term",
  "matchers",
  "once_cell",
  "regex",

--- a/amd64.dockerfile
+++ b/amd64.dockerfile
@@ -7,7 +7,10 @@ FROM $RUST_IMAGE as build
 ARG TARGETARCH
 WORKDIR /build
 COPY Cargo.toml Cargo.lock .
-COPY controller /build/
+RUN mkdir -p ./cli/src && \
+    echo 'fn main() {}' > ./cli/src/main.rs
+COPY cli/Cargo.toml ./cli/Cargo.toml
+COPY controller ./controller
 RUN --mount=type=cache,target=target \
     --mount=type=cache,from=rust:1.63.0,source=/usr/local/cargo,target=/usr/local/cargo \
     cargo fetch --locked

--- a/arm.dockerfile
+++ b/arm.dockerfile
@@ -11,7 +11,10 @@ RUN apt-get update && \
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
 WORKDIR /build
 COPY Cargo.toml Cargo.lock .
-COPY controller /build/
+RUN mkdir -p ./cli/src && \
+    echo 'fn main() {}' > ./cli/src/main.rs
+COPY cli/Cargo.toml ./cli/Cargo.toml
+COPY controller ./controller
 RUN --mount=type=cache,target=target \
     --mount=type=cache,from=rust:1.63.0,source=/usr/local/cargo,target=/usr/local/cargo \
     cargo fetch --locked

--- a/arm64.dockerfile
+++ b/arm64.dockerfile
@@ -11,7 +11,10 @@ RUN apt-get update && \
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 WORKDIR /build
 COPY Cargo.toml Cargo.lock .
-COPY controller /build/
+RUN mkdir -p ./cli/src && \
+    echo 'fn main() {}' > ./cli/src/main.rs
+COPY cli/Cargo.toml ./cli/Cargo.toml
+COPY controller ./controller
 RUN --mount=type=cache,target=target \
     --mount=type=cache,from=rust:1.63.0,source=/usr/local/cargo,target=/usr/local/cargo \
     cargo fetch --locked

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,29 +7,29 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3", default-features = false, features = ["derive", "env", "std"] }
-k8s-openapi = { version = "0.15", default-features = false, features = ["v1_20"] }
 linkerd-failover-controller = { path = "../controller" }
 serde = "1"
 serde_json = "1"
 
-[dependencies.kube]
-version = "0.74"
+[dependencies.clap]
+version = "4"
 default-features = false
-features = [
-    "client",
-    "derive",
-    "openssl-tls",
-    "runtime",
-]
+features = ["color", "derive", "env", "help", "std", "suggestions"]
+
+[dependencies.k8s-openapi]
+version = "0.16"
+default-features = false
+features = ["v1_21"]
+
+[dependencies.kube]
+version = "0.75"
+default-features = false
+features = ["client", "derive", "openssl-tls", "runtime"]
 
 [dependencies.kubert]
-version = "0.9"
+version = "0.11"
 default-features = false
-features = [
-    "clap",
-    "runtime",
-]
+features = ["clap", "runtime"]
 
 [dependencies.tokio]
 version = "1"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,62 +1,73 @@
-use anyhow::{bail, Result};
-use clap::{ArgEnum, Parser, Subcommand};
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use kubert::ClientArgs;
 use linkerd_failover_cli::{check, status};
 
 #[derive(Parser)]
-#[clap(name = "linkerd-failover", author, version, about, long_about = None)]
-#[clap(propagate_version = true)]
+#[command(name = "linkerd-failover", author, version, about, long_about = None)]
 /// Manages the failover extension of Linkerd service mesh.
 struct Cli {
-    #[clap(subcommand)]
-    command: Commands,
-
-    #[clap(flatten)]
+    #[command(flatten)]
     client: kubert::ClientArgs,
+
+    #[command(subcommand)]
+    command: Commands,
 }
 
-#[derive(ArgEnum, Clone)]
+#[derive(clap::ValueEnum, Clone)]
 enum OutputMode {
     Table,
     Json,
 }
 
-#[derive(Subcommand)]
+#[derive(clap::Subcommand)]
 enum Commands {
-    /// Output commands to install the failover extension
+    /// Output kubernetes manifests describing the failover extension
     Install {
-        #[clap(long)]
+        #[arg(long)]
         ignore_cluster: bool,
     },
-    /// Output commands to uninstall the failover extension
+
+    /// Output kubernetes metadata manifests describing the failover extension
     Uninstall,
+
     /// Check the failover extension installation for potential problems
     Check {
-        #[clap(long)]
+        /// Check a cluster before installation
+        #[arg(long)]
         pre: bool,
-        #[clap(arg_enum, short, long, default_value = "table")]
+
+        /// Output format
+        #[arg(short, long, default_value = "table")]
         output: OutputMode,
     },
+
     /// Get the current status of failovers in the cluster
     Status {
-        #[clap(
+        /// Label selector for TrafficSplits controlled by the failover
+        /// extension
+        #[arg(
             short = 'l',
             long = "selector",
             default_value = "failover.linkerd.io/controlled-by"
         )]
         label_selector: String,
-        #[clap(arg_enum, short, long, default_value = "table")]
+
+        /// Output format
+        #[arg(short, long, default_value = "table")]
         output: OutputMode,
     },
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Cli::parse();
+    let Cli { client, command } = Cli::parse();
 
-    match cli.command {
+    match command {
         Commands::Install { ignore_cluster } => {
             if !ignore_cluster {
-                let client = cli.client.try_client().await?;
+                let client = try_client(client).await?;
+
                 if !check::traffic_split_check(client).await.success() {
                     bail!(
                         "The Failover extension requires that the SMI extension is installed. Install the SMI extension first by running:
@@ -66,6 +77,7 @@ helm repo up
 helm install linkerd-smi -n linkerd-smi --create-namespace linkerd-smi/linkerd-smi");
                 }
             }
+
             bail!(
                 "Run the following commands to install the Failover extension:
 
@@ -74,6 +86,7 @@ helm repo up
 
 helm install linkerd-failover -n linkerd-failover --create-namespace --devel linkerd-edge/linkerd-failover");
         }
+
         Commands::Uninstall => {
             bail!(
                 "Run the following command to uninstall the Failover extension:
@@ -81,22 +94,27 @@ helm install linkerd-failover -n linkerd-failover --create-namespace --devel lin
 helm uninstall linkerd-failover"
             );
         }
-        Commands::Check { ref output, pre } => {
-            let client = cli.client.try_client().await?;
+
+        Commands::Check { output, pre } => {
+            let client = try_client(client).await?;
+
             let results = check::run_checks(client, pre).await;
             let success = match output {
                 OutputMode::Table => check::print_checks(results),
                 OutputMode::Json => check::json_print_checks(results),
             };
+
             if !success {
                 std::process::exit(1);
             }
         }
+
         Commands::Status {
-            ref output,
+            output,
             label_selector,
         } => {
-            let client = cli.client.try_client().await?;
+            let client = try_client(client).await?;
+
             let results = status::status(client, label_selector.as_str()).await?;
             match output {
                 OutputMode::Table => status::print_status(&results),
@@ -104,5 +122,13 @@ helm uninstall linkerd-failover"
             }
         }
     };
+
     Ok(())
+}
+
+async fn try_client(client: ClientArgs) -> Result<kubert::client::Client> {
+    client
+        .try_client()
+        .await
+        .context("failed to load a Kubernetes client configuration")
 }

--- a/cli/src/status.rs
+++ b/cli/src/status.rs
@@ -1,5 +1,5 @@
 use crate::table::{Column, Table};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use kube::{api::ListParams, Api, Client, ResourceExt};
 use linkerd_failover_controller::TrafficSplit;
 use serde::Serialize;
@@ -33,7 +33,10 @@ impl Display for FailoverStatus {
 pub async fn status(client: Client, label_selector: &str) -> Result<Vec<TrafficSplitStatus>> {
     let api = Api::<TrafficSplit>::all(client);
     let list_params = ListParams::default().labels(label_selector);
-    let traffic_splits = api.list(&list_params).await?;
+    let traffic_splits = api
+        .list(&list_params)
+        .await
+        .context("failed to list TrafficSplits")?;
     let statuses = traffic_splits
         .items
         .into_iter()

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -7,32 +7,32 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3", default-features = false, features = ["derive", "env", "std"] }
 futures = "0.3"
-k8s-openapi = { version = "0.15", default-features = false, features = ["v1_20"] }
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio-stream = "0.1"
 tracing = "0.1"
 
-[dependencies.kube]
-version = "0.74"
+[dependencies.clap]
+version = "4"
 default-features = false
-features = [
-    "client",
-    "derive",
-    "openssl-tls",
-    "runtime",
-]
+features = ["derive", "env", "help", "std"]
+
+[dependencies.k8s-openapi]
+version = "0.16"
+default-features = false
+features = ["v1_21"]
+
+[dependencies.kube]
+version = "0.75"
+default-features = false
+features = ["client", "derive", "openssl-tls", "runtime"]
 
 [dependencies.kubert]
-version = "0.9"
+version = "0.11.1"
 default-features = false
-features = [
-    "clap",
-    "runtime",
-]
+features = ["clap", "runtime"]
 
 [dependencies.tokio]
 version = "1"
@@ -41,4 +41,8 @@ features = ["macros", "parking_lot", "rt", "rt-multi-thread"]
 [dev-dependencies]
 tokio-stream = "0.1"
 tokio-test = "0.4"
-tracing-subscriber = "0.3"
+
+[dev-dependencies.tracing-subscriber]
+version = "0.3"
+default-features = false
+features = ["fmt"]

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -9,25 +9,25 @@ use tokio::{sync::mpsc, time};
 use tracing::Instrument;
 
 #[derive(Parser)]
-#[clap(version)]
+#[command(version)]
 struct Args {
-    #[clap(
+    #[arg(
         long,
         env = "LINKERD_FAILOVER_LOG_LEVEL",
         default_value = "linkerd=info,warn"
     )]
     log_level: kubert::LogFilter,
 
-    #[clap(long, default_value = "plain")]
+    #[arg(long, default_value = "plain")]
     log_format: kubert::LogFormat,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     client: kubert::ClientArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     admin: kubert::AdminArgs,
 
-    #[clap(long, default_value = "failover.linkerd.io/controlled-by", short = 'l')]
+    #[arg(long, default_value = "failover.linkerd.io/controlled-by", short = 'l')]
     selector: String,
 }
 
@@ -48,8 +48,8 @@ async fn main() -> Result<()> {
         .build()
         .await?;
 
-    // Create cached watches for traffic splits and endpoints. This enable us to watch for updates
-    // and to lookup previously-observed objects.
+    // Create cached watches for traffic splits and endpoints. This enables us to watch for
+    // updates and to lookup previously-observed objects.
     let (endpoints, endpoints_events) = runtime.cache_all(ListParams::default());
     let (traffic_splits, traffic_split_events) =
         runtime.cache_all(ListParams::default().labels(&selector));


### PR DESCRIPTION
* Update clap to v4, with updated dervie macros
* Update kube to v0.75
* Update kubert to v0.11
* Update k8s-openapi to v0.16
* Minimize tracing-subscriber features in dev to avoid RUSTSEC warnings
* Improve help messages (via doc comments)
* Improve error handling when a Kubernetes client cannot be loaded
* Improve `status` error handling when the TrafficSplit CRD does not exist
* Fix rust-analyzer extension ID in Devcontainer
* Whitespace for readability