### PR TITLE
Update kubert to v0.12, kube to v0.76

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.75.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb19108692aeafebb108fd0a1c381c06ac4c03859652599420975165e939b8a"
+checksum = "fcf241a3a42bca4a2d1c21f2f34a659655032a7858270c7791ad4433aa8d79cb"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -671,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.75.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e1a80ecd1b1438a2fc004549e155d47250b9e01fbfcf4cfbe9c8b56a085593"
+checksum = "7e442b4e6d55c4b3d0c0c70d79a8865bf17e2c33725f9404bfcb8a29ee002ffe"
 dependencies = [
  "base64",
  "bytes",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.75.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d780f2bb048eeef64a4c6b2582d26a0fe19e30b4d3cc9e081616e1779c5d47"
+checksum = "eca2e1b1528287ba61602bbd17d0aa717fbb4d0fb257f4fa3a5fa884116ef778"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -724,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.75.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98459d53b2841237392cd6959956185b2df15c19d32c3b275ed6ca7b7ee1adae"
+checksum = "1af50996adb7e1251960d278859772fa30df99879dc154d792e36832209637cb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -737,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.75.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7769af142ee2e46bfa44bd393cf7f40b9d8b80d2e11f6317399551ed17760beb"
+checksum = "0b9b312c38884a3f41d67e2f7580824b6f45d360b98497325b5630664b3a359d"
 dependencies = [
  "ahash",
  "backoff",
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "kubert"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde503669a3277ab3c576ab3349fb21a7e82288210369b37ed65d88a14cf3e51"
+checksum = "299878b335dccc1c2284b0f10a685daf101bd2f95facbc3ecadb2a6f4bdaed0a"
 dependencies = [
  "clap",
  "drain",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,12 +28,12 @@ default-features = false
 features = ["v1_21"]
 
 [dependencies.kube]
-version = "0.75"
+version = "0.76"
 default-features = false
 features = ["client", "derive", "openssl-tls", "runtime"]
 
 [dependencies.kubert]
-version = "0.11"
+version = "0.12"
 default-features = false
 features = ["clap", "runtime"]
 

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -31,12 +31,12 @@ default-features = false
 features = ["v1_21"]
 
 [dependencies.kube]
-version = "0.75"
+version = "0.76"
 default-features = false
 features = ["client", "derive", "openssl-tls", "runtime"]
 
 [dependencies.kubert]
-version = "0.11.1"
+version = "0.12"
 default-features = false
 features = ["clap", "runtime"]
 


### PR DESCRIPTION
Signed-off-by: Oliver Gould <ver@buoyant.io>