### PR TITLE
Fix RBAC to emit events

### DIFF
--- a/charts/linkerd-failover/templates/linkerd-failover-rbac.yaml
+++ b/charts/linkerd-failover/templates/linkerd-failover-rbac.yaml
@@ -12,7 +12,7 @@ rules:
 - apiGroups: [""]
   resources: ["endpoints"]
   verbs: ["list", "get", "watch"]
-- apiGroups: [""]
+- apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["create"]
 ---


### PR DESCRIPTION
Followup to #411

The actual group for the Event resource is `events.k8s.io`.