### PR TITLE
v0.1.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 0.1.1
+
+- Dependencies bumps, clearing vulnerabilities (with no known exploits) on libc
+  and openssl
+- Build CLI and controller as static binaries
+- The controller docker image is now based on `scratch`
+- Added RBAC to allow publishing events associated to the TrafficSplit resource
+
 ## 0.1.0
 
 Even though 0.0.1-edge was stable enough, this is officially the first stable

--- a/charts/linkerd-failover-tests/Chart.yaml
+++ b/charts/linkerd-failover-tests/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
 kubeVersion: ">=1.20.0-0"
 sources:
 - https://github.com/linkerd/linkerd-failover/
-appVersion: 0.1.0
-version: 0.1.0
+appVersion: 0.1.1
+version: 0.1.1
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-failover-tests/README.md
+++ b/charts/linkerd-failover-tests/README.md
@@ -1,9 +1,9 @@
 <!-- markdownlint-disable -->
 # linkerd-failover-tests
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>
 

--- a/charts/linkerd-failover/Chart.yaml
+++ b/charts/linkerd-failover/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
 kubeVersion: ">=1.20.0-0"
 sources:
 - https://github.com/linkerd/linkerd-failover/
-appVersion: 0.1.0
-version: 0.1.0
+appVersion: 0.1.1
+version: 0.1.1
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-failover/README.md
+++ b/charts/linkerd-failover/README.md
@@ -1,9 +1,9 @@
 <!-- markdownlint-disable -->
 # linkerd-failover
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>
 
@@ -108,7 +108,7 @@ Kubernetes: `>=1.20.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image | object | `{"name":"failover","registry":"cr.l5d.io/linkerd","tag":"0.1.0"}` | Docker image |
+| image | object | `{"name":"failover","registry":"cr.l5d.io/linkerd","tag":"0.1.1"}` | Docker image |
 | logFormat | string | `"plain"` | Log format (`plain` or `json`) |
 | logLevel | string | `"linkerd=info,warn"` | Log level |
 | selector | string | `nil` | Determines which `TrafficSplit` instances to consider for failover. If empty, defaults to failover.linkerd.io/controlled-by={{ .Release.Name }} |

--- a/charts/linkerd-failover/values.yaml
+++ b/charts/linkerd-failover/values.yaml
@@ -8,7 +8,7 @@ logFormat: plain
 image:
   registry: cr.l5d.io/linkerd
   name: failover
-  tag: 0.1.0
+  tag: 0.1.1
 
 # -- Determines which `TrafficSplit` instances to consider for failover. If
 # empty, defaults to failover.linkerd.io/controlled-by={{ .Release.Name }}


### PR DESCRIPTION
## 0.1.1

- Dependencies bumps, clearing vulnerabilities (with no known exploits) on libc and openssl
- Build CLI and controller as static binaries
- The controller docker image is now based on `scratch`
- Added RBAC to allow publishing events associated to the TrafficSplit resource