### PR TITLE
Replace `curlimages/curl` with `extension-init`

### DIFF
--- a/charts/linkerd-failover/README.md
+++ b/charts/linkerd-failover/README.md
@@ -109,8 +109,13 @@ Kubernetes: `>=1.20.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | object | `{"name":"failover","registry":"cr.l5d.io/linkerd","tag":"0.1.1"}` | Docker image |
+| linkerdNamespace | string | `"linkerd"` | Namespace of the Linkerd core control-plane install |
 | logFormat | string | `"plain"` | Log format (`plain` or `json`) |
 | logLevel | string | `"linkerd=info,warn"` | Log level |
+| namespaceMetadata.image.name | string | `"extension-init"` | Docker image name for the namespace-metadata instance |
+| namespaceMetadata.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the namespace-metadata instance |
+| namespaceMetadata.image.registry | string | `"cr.l5d.io/linkerd"` | Docker registry for the namespace-metadata instance |
+| namespaceMetadata.image.tag | string | `"v0.1.0"` | Docker image tag for the namespace-metadata instance |
 | selector | string | `nil` | Determines which `TrafficSplit` instances to consider for failover. If empty, defaults to failover.linkerd.io/controlled-by={{ .Release.Name }} |
 
 ----------------------------------------------

--- a/charts/linkerd-failover/templates/namespace-metadata-rbac.yaml
+++ b/charts/linkerd-failover/templates/namespace-metadata-rbac.yaml
@@ -37,4 +37,23 @@ subjects:
 - kind: ServiceAccount
   name: namespace-metadata
   namespace: {{.Release.Namespace}}
-  
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: {{ .Values.linkerdNamespace }}
+  labels:
+    linkerd.io/extension: failover
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: failover-namespace-metadata-linkerd-config
+roleRef:
+  kind: Role
+  name: ext-namespace-metadata-linkerd-config
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: namespace-metadata
+  namespace: {{.Release.Namespace}}

--- a/charts/linkerd-failover/templates/namespace-metadata.yaml
+++ b/charts/linkerd-failover/templates/namespace-metadata.yaml
@@ -22,19 +22,16 @@ spec:
       serviceAccountName: namespace-metadata
       containers:
       - name: namespace-metadata
-        image: curlimages/curl:7.78.0
-        command: ["/bin/sh"]
+        image: {{.Values.namespaceMetadata.image.registry}}/{{.Values.namespaceMetadata.image.name}}:{{.Values.namespaceMetadata.image.tag}}
+        imagePullPolicy: {{.Values.namespaceMetadata.image.pullPolicy }}
         args:
-        - -c
-        - |
-          ops=''
-          token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-          ns=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
-          if echo "$ns" | grep -vq 'labels'; then
-            ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
-          fi
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/linkerd.io~1extension\", \"value\": \"failover\"}"
-          curl -kfv -XPATCH -H "Content-Type: application/json-patch+json" -H "Authorization: Bearer $token" \
-            -d "[$ops]" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}?fieldManager=kubectl-label"
+        - --log-format
+        - {{.Values.logFormat}}
+        - --log-level
+        - {{.Values.logLevel}}
+        - --extension
+        - failover
+        - --namespace
+        - {{.Release.Namespace}}
+        - --linkerd-namespace
+        - {{.Values.linkerdNamespace}}

--- a/charts/linkerd-failover/values.yaml
+++ b/charts/linkerd-failover/values.yaml
@@ -1,3 +1,6 @@
+# -- Namespace of the Linkerd core control-plane install
+linkerdNamespace: linkerd
+
 # -- Log level
 logLevel: linkerd=info,warn
 
@@ -13,3 +16,14 @@ image:
 # -- Determines which `TrafficSplit` instances to consider for failover. If
 # empty, defaults to failover.linkerd.io/controlled-by={{ .Release.Name }}
 selector:
+
+namespaceMetadata:
+  image:
+    # -- Docker registry for the namespace-metadata instance
+    registry: cr.l5d.io/linkerd
+    # -- Docker image name for the namespace-metadata instance
+    name: extension-init
+    # -- Docker image tag for the namespace-metadata instance
+    tag: v0.1.0
+    # -- Pull policy for the namespace-metadata instance
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
Replaced `curlimages/curl` docker image in the `namespace-metadata` Job with linkerd's `extension-init` image, to avoid all the OS luggage included in the former, which generates CVE alerts.

As an added benefit, this extracts the control-planes CNI config to be able to set the PSA's `pod-security.kubernetes.io/enforce` label in the `linkerd-failover` namespace.