### PR TITLE
Fix test suite

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,7 +51,7 @@ jobs:
         curl -sL https://run.linkerd.io/install-edge | sh
         export PATH=$PATH:~/.linkerd2/bin
         linkerd install --crds | kubectl apply -f -
-        linkerd install | kubectl apply -f -
+        linkerd install --set proxy.enableShutdownEndpoint=true | kubectl apply -f -
         linkerd check
     - name: Install linkerd-smi
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         curl -sL https://run.linkerd.io/install | sh
         export PATH=$PATH:~/.linkerd2/bin
         linkerd install --crds | kubectl apply -f -
-        linkerd install | kubectl apply -f -
+        linkerd install --set proxy.enableShutdownEndpoint=true | kubectl apply -f -
         linkerd check
     - name: Install linkerd-smi
       run: |


### PR DESCRIPTION
The tests rely on calling the proxy's `/shutdown` endpoint, that now needs to be explicitly enabled via a flag.